### PR TITLE
[tests] Use unittest2 to support unit testing on Python 2.6 or older

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 coverage
 Paver>=1.0.0
+unittest2

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import unittest
+import unittest2 as unittest
 import doctest
 import ldapom
 import openldap


### PR DESCRIPTION
At the moment, no unittests are executed if using python 2.6.
