### PR TITLE
Add read-only mode that doesn't modify entries

### DIFF
--- a/ldapom/entry.py
+++ b/ldapom/entry.py
@@ -86,7 +86,7 @@ class LDAPEntry(compat.UnicodeMixin, object):
             else:
                 return attribute.values
         else:
-            if attribute_type.multi_value:
+            if attribute_type.multi_value and not self._connection.is_read_only():
                 setattr(self, name, set())
                 return self.get_attribute(name).values
             else:

--- a/ldapom/error.py
+++ b/ldapom/error.py
@@ -29,3 +29,6 @@ class LDAPAttributeNameNotFoundError(LDAPomError):
 
 class LDAPCouldNotFetchAttributeTypes(LDAPomError):
     pass
+
+class LDAPomReadOnlyError(LDAPomError):
+    pass


### PR DESCRIPTION
This will also make hasattr on LDAPEntry more predictable in situations
where we do not want an empty set returned to add values but rather want
to know whether or not the entry has that specific attribute or not.