### PR TITLE
Add ability to check if an attribute exists

### DIFF
--- a/ldapom/attribute.py
+++ b/ldapom/attribute.py
@@ -58,6 +58,9 @@ class LDAPAttributeBase(compat.UnicodeMixin, object):
         c._values = copy.deepcopy(self._values)
         return c
 
+    def is_present(self):
+        return bool(self._values)
+
 
 class SingleValueAttributeMixin(object):
     single_value = True

--- a/ldapom/entry.py
+++ b/ldapom/entry.py
@@ -162,3 +162,15 @@ class LDAPEntry(compat.UnicodeMixin, object):
         :rtype: boolean
         """
         return self._connection.can_bind(self.dn, bind_password)
+
+    def has_attribute(self, attribute):
+        """Return whether or not this attribute really exists
+
+        :param attribute: Name of the attribute
+        :type attribute: str
+        :rtype: boolean
+        """
+        attribute = self.get_attribute(attribute)
+        if attribute is None:
+            return False
+        return attribute.is_present()


### PR DESCRIPTION
Since hasattr isn't sufficient to check if attributes really exist
and aren't just empty sets for convenience of modifying entries
add functionality to entries to check if a given attribute exists.

Based on what @leonhandreke suggested in #38 - hope this is close to what you visioned. Sorry for the long delay.